### PR TITLE
type annotations

### DIFF
--- a/src/animation_asset.luau
+++ b/src/animation_asset.luau
@@ -27,7 +27,7 @@ export type Identity = {
 	looping: boolean,
 }
 
-local function recursive_tree_from_pose(keyframe: Keyframe, poses: { [string]: PoseNode }, root_pose: Pose)
+local function recursive_tree_from_pose(keyframe: Keyframe, poses: { [string]: PoseNode }, root_pose: Pose): ()
 	local sub_poses = (root_pose:GetSubPoses() :: any) :: { Pose }
 
 	for _, sub_pose in sub_poses do
@@ -70,7 +70,7 @@ function animation_asset.load_keyframe_sequence(keyframe_sequence: KeyframeSeque
 		})
 	end
 
-	table.sort(keyframe_nodes, function(left, right)
+	table.sort(keyframe_nodes, function(left: KeyframeNode, right: KeyframeNode): boolean
 		return left.time < right.time
 	end)
 

--- a/src/animation_solver.luau
+++ b/src/animation_solver.luau
@@ -60,7 +60,7 @@ local function get_keyframe_after(
 	return closestKeyframe
 end
 
-local function calculate(rig: { [string]: CFrame }, info: create_rig.LimbInfo, origin: CFrame)
+local function calculate(rig: { [string]: CFrame }, info: create_rig.LimbInfo, origin: CFrame): ()
 	local result_transform = origin * info.coordinate_frame0 * info.transform * info.coordinate_frame1
 
 	rig[info.name] = result_transform
@@ -74,7 +74,7 @@ local function animation_solver(
 	rig: create_rig.Identity,
 	anim_playbacks: { [animation_asset.Identity]: AnimationPlayback },
 	root: CFrame
-)
+): ()
 	local limb_info_array = rig.flattened
 	for _, node in limb_info_array do
 		node.priority = -1


### PR DESCRIPTION
# Type Annotations

## Summary

Add explicit type annotations to places in the module where types were previously inferred in order to enhance readability, user experience, and utilize features of luau's type system.

## Motivation

Implicit typing can lead to de-optimizations by Luau's compiler, and it's generally a good idea to include annotations in function signatures to keep APIs "concrete". The goal is to avoid accidental breaking changes or unknowing de-optimization due to a lack of type information. I've no clue what this PR changed, but there are 2 lines less bytecode. Case and point, open and shut.

## Design

Add explicit type annotation to all return and parameter types.

## Drawbacks

More verbose code.

## Alternatives

Do nothing, and leave implicit types as-is; this is not desirable, because explicit type annotations make it easier to understand the intent of a program.
