### PR TITLE
feat: add skip_result_coordinate_frames parameter to solve_animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+-   Added optional `skip_result_coordinate_frames` parameter to `solve_animation` to bypass CFrame caching when not needed.
+
 ## 0.2.0
 
 ### Added

--- a/src/animation_solver.luau
+++ b/src/animation_solver.luau
@@ -53,7 +53,8 @@ local function animation_solver(
 	tracks: {
 		[animation_asset.Identity]: AnimationTrack,
 	},
-	root: CFrame
+	root: CFrame,
+	skip_result_coordinate_frames: boolean?
 )
 	local limb_transforms = rig.limb_transforms
 	for _, limb in limb_transforms do
@@ -158,26 +159,28 @@ local function animation_solver(
 		end
 	end
 
-	local result_coordinate_frames: { [string]: CFrame } = rig.result_coordinate_frames
-	result_coordinate_frames["root"] = root
+	if not skip_result_coordinate_frames then
+		local result_coordinate_frames: { [string]: CFrame } = rig.result_coordinate_frames
+		result_coordinate_frames["root"] = root
 
-	for index, limb in rig.limbs do
-		local limb_transform = limb_transforms[index]
+		for index, limb in rig.limbs do
+			local limb_transform = limb_transforms[index]
 
-		local position = limb_transform.position
-		local quat_vector = limb_transform.quat_vector
-		local quat_scalar = limb_transform.quat_scalar
+			local position = limb_transform.position
+			local quat_vector = limb_transform.quat_vector
+			local quat_scalar = limb_transform.quat_scalar
 
-		--stylua: ignore
-		local transform = CFrame.new(
-			position.x, position.y, position.z,
-			quat_vector.x, quat_vector.y, quat_vector.z, quat_scalar
-		)
+			--stylua: ignore
+			local transform = CFrame.new(
+				position.x, position.y, position.z,
+				quat_vector.x, quat_vector.y, quat_vector.z, quat_scalar
+			)
 
-		result_coordinate_frames[limb.name] = result_coordinate_frames[limb.depends_on]
-			* limb.c0
-			* transform
-			* limb.c1
+			result_coordinate_frames[limb.name] = result_coordinate_frames[limb.depends_on]
+				* limb.c0
+				* transform
+				* limb.c1
+		end
 	end
 end
 

--- a/src/init.luau
+++ b/src/init.luau
@@ -31,7 +31,7 @@ local rig = require("@self/rig")
 --[=[
 	@function solve_animation
 	@within Crunchyroll
-	
+
 	The primary function of the module. This will solve the animation for a rig.
 	Example:
 	```lua
@@ -47,10 +47,11 @@ local rig = require("@self/rig")
 			},
 		}, character.HumanoidRootPart.CFrame)
 	```
-	
+
 	@param rig Rig
 	@param tracks { [AnimationAsset]: AnimationTrack }
 	@param root CFrame
+	@param skip_result_coordinate_frames boolean?
 ]=]
 
 --[=[


### PR DESCRIPTION
Allows bypassing CFrame caching when unused.